### PR TITLE
Fix FileIOCatalog setProperties return value

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/FileIOCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/io/FileIOCatalog.java
@@ -252,7 +252,7 @@ public class FileIOCatalog extends BaseMetastoreCatalog
     } catch (CommitFailedException e) {
       return false; // sigh.
     }
-    return false;
+    return true;
   }
 
   @Override


### PR DESCRIPTION
## Summary
- ensure `setProperties` returns `true` after a successful update

## Testing
- `./gradlew test --no-daemon -x integTest` *(fails: Could not download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_683fb5aa75888324bff8036cc81a90eb